### PR TITLE
Fix off-by-one bug causing bigger displays to misbehave

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -46,7 +46,7 @@ pub enum DataInterval {
 /// A command that can be issued to the controller.
 #[derive(Clone, Copy)]
 pub enum Command {
-    /// Set the panel (PSR)
+    /// Set the panel (PSR), overwritten by ResolutionSetting (TRES)
     PanelSetting(DisplayResolution),
     /// Gate scanning sequence and direction (PWR)
     PowerSetting(u8, u8, u8),
@@ -80,7 +80,7 @@ pub enum Command {
     VCOMDataIntervalSetting(u8, DataPolarity, DataInterval),
     /// Low Power Detection
     /// TCON Setting
-    /// ResolutionSetting (TRES)
+    /// ResolutionSetting (TRES). Has higher priority than (PSR)
     ResolutionSetting(u8, u16),
     /// Revision
     /// Get Status
@@ -226,8 +226,8 @@ impl Command {
                 pack!(buf, 0x50, [vbd | ddx | cdi])
             }
             ResolutionSetting(horiz, vertical) => {
-                let vres_hi = ((vertical & 0x80) >> 7) as u8;
-                let vres_lo = (vertical & 0x7F) as u8;
+                let vres_hi = ((vertical & 0x100) >> 8) as u8;
+                let vres_lo = (vertical & 0xFF) as u8;
                 pack!(buf, 0x61, [horiz, vres_hi, vres_lo])
             }
             VCMDCSetting(vcom_dc) => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,6 +68,7 @@ impl Builder {
     /// Set the panel
     ///
     /// Defaults to 160x296. Corresponds to command 0x0.
+    /// Is overwritten by the row and column values in [Builder::dimensions]
     pub fn panel_setting(self, res: DisplayResolution) -> Self {
         Self {
             panel_setting: Command::PanelSetting(res),
@@ -109,6 +110,8 @@ impl Builder {
     ///
     /// There is no default for this setting. The dimensions must be set for the builder to
     /// successfully build a Config.
+    ///
+    /// Has higher priority in than the [Builder::panel_setting] value.
     pub fn dimensions(self, dimensions: Dimensions) -> Self {
         assert!(
             dimensions.cols % 4 == 0,


### PR DESCRIPTION
Hi, looks like I found a bug in the library when trying to get my 2.9" EDP display with 292x128 resolution to work.

When setting the values for resolution setting (`TRES`), there is off-by-one error when setting the highest bit since it should be the 9th bit of the row's value, not 8th. Because of this, displays with rows greater than what fits in byte (over 255 rows) will misbehave.

I also added couple of comments from datasheet, as I think they are useful. Maybe there is better way to convey the message, such as even removing the `Builder::panel_setting()`, as the `Builder::dimensions()` is required, which will always have precedence over it according to the datasheet.